### PR TITLE
Partial deprecation warning

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -13,7 +13,7 @@
     = render "layouts/partials/google_analytics"
     = render "layouts/partials/chartbeat_header"
   %body{:class => "#{controller_name} #{action_name}"}
-    = render 'layouts/partials/facebook.html'
+    = render 'layouts/partials/facebook'
     
     #appstores
       = link_to_app_store image_tag("web/app-store-fr-small.png")


### PR DESCRIPTION
Fix this warning : 

```
DEPRECATION WARNING: Passing the format in the template name is deprecated. Please pass render with :formats => [:html] instead. (called from _app_views_layouts_application_html_haml__2515002154092969009_70295921967440 at /data/Projets/voxe-web/app/views/layouts/application.html.haml:16)
```
